### PR TITLE
fix to missing stylesheet problem

### DIFF
--- a/app/public/home.html
+++ b/app/public/home.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="UTF-8">
     <title>Savannah Tour of Homes and Gardens</title>
@@ -7,22 +8,22 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="assets/style.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-    <script src="apiRoutes.js"></script>
-    <script src="htmlRoutes.js"></script>
 </head>
+
 <body>
     <div class="container">
         <h1 class="text-center">Savannah Tour of Homes and Gardens</h1>
-		<br>
+        <br>
         <div class="text-center">
-			<a href="/location"><button type="button" class="btn btn-lg btn-danger"><span class="glyphicon glyphicon-credit-card"></span> Add Location</button></a>
+            <a href="/location"><button type="button" class="btn btn-lg btn-danger"><span class="glyphicon glyphicon-credit-card"></span> Add Location</button></a>
         </div>
         <footer class="footer">
-	      <div class="container">
-		        <p><a href="/api/locations">API Locations List</a></p>
+            <div class="container">
+                <p><a href="/api/locations">API Locations List</a></p>
                 <p><a href="/api/friendsoftour">API Friends of Tour List</a></p>
-	      </div>
-	    </footer>
+            </div>
+        </footer>
     </div>
 </body>
+
 </html>

--- a/app/routing/apiRoutes.js
+++ b/app/routing/apiRoutes.js
@@ -27,24 +27,25 @@ db.once("open", function() {
   console.log("Mongoose connection successful.");
 });
 
-api.get("/friendsoftour", function(req, response) {
-    db.FriendsofTour.find({}, function (err, friendsoftour) {
-        if (err) return handleError(err);
+module.exports = function(app) {
+
+    api.get("/friendsoftour", function(req, response) {
+        db.FriendsofTour.find({}, function (err, friendsoftour) {
+            if (err) return handleError(err);
+        });
     });
-});
 
-api.get("/locations", function(req, response) {
-    db.Location.find({}, function (err, locations) {
-        if (err) return handleError(err);
+    api.get("/locations", function(req, response) {
+        db.Location.find({}, function (err, locations) {
+            if (err) return handleError(err);
+        });
     });
-});
 
-api.post("/new/location", function(req, res) {
-    var newLocation = req.body;
-    console.log(newLocation);
+    api.post("/new/location", function(req, res) {
+        var newLocation = req.body;
+        console.log(newLocation);
 
-    connection.query("INSERT INTO Location SET ?", { name:newLocation.name, type:newLocation.type, map:newLocation.map, address:newLocation.address, description:newLocation.description, image:newLocation.image, pos:newLocation.pos}, function (err, res) { });
-    res.json(newLocation);
-});
-
-module.exports = api;
+        connection.query("INSERT INTO Location SET ?", { name:newLocation.name, type:newLocation.type, map:newLocation.map, address:newLocation.address, description:newLocation.description, image:newLocation.image, pos:newLocation.pos}, function (err, res) { });
+        res.json(newLocation);
+    });
+};

--- a/app/routing/htmlRoutes.js
+++ b/app/routing/htmlRoutes.js
@@ -10,7 +10,8 @@ html.use(bodyParser.text());
 html.use(bodyParser.json({ type: "application/vnd.api+json" }));
 
 html.get("/", function(req, res) {
-    res.sendFile(path.join(__dirname, "../public/home.html"));
+   
+   res.sendFile(path.join(__dirname, "../public/home.html"));
 });
 
 module.exports = html;

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ app.use(bodyParser.urlencoded({
   extended: false
 }));
 
-app.use(express.static("public"));
+app.use(express.static(__dirname + "/app/public"));
 
 app.listen(PORT, function() {
   console.log("App listening on PORT " + PORT);


### PR DESCRIPTION
Katharina, 
I fixed the stylesheet issue and removed the unnecessary calls to apiRoutes.js and htmlRoutes.js in the home.html file's head tag. 

The stylesheet problem was that in the set-up for the static routes in server.js, the path description has to be a string, not path notation:

You had 
app.use(express.static(__dirname + "./app/public")); 

but since we're not using a join method but just concatenating a current working directory (__dirname) with the path that follows as a string, the "./app" becomes simply "/app":

app.use(express.static(__dirname + "/app/public"));